### PR TITLE
Trigger page reload for browser sync.

### DIFF
--- a/generators/app/templates/_gulpfile.js
+++ b/generators/app/templates/_gulpfile.js
@@ -36,7 +36,8 @@ var path = {
 gulp.task('browser-sync', ['sass'], function() {
     browserSync.init({
         proxy: "<%= projectHost %>",
-        notify: false
+        notify: false,
+        injectChanges: false
     });
 });
 


### PR DESCRIPTION
Injecting changes into the css does not work with Drupal.

It does not know what to do with files loaded via @import tags like this:

<style>
  @import url('/sites/.../style.css');
</style>